### PR TITLE
Team tab unified workspace

### DIFF
--- a/app/(protected)/teamWorkspace.tsx
+++ b/app/(protected)/teamWorkspace.tsx
@@ -2,6 +2,26 @@
  * Team Command Center
  *
  * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠️  DEPRECATED - DO NOT USE FOR PRIMARY NAVIGATION
+ * ═══════════════════════════════════════════════════════════════════════════
+ * 
+ * This screen has been superseded by the unified Team Tab (`trainings.tsx`).
+ * 
+ * As of the Team Tab Unified Workspace update:
+ * - The Team tab IS the team workspace when an activeTeam is selected
+ * - There should be NO additional "team page" click required to see team content
+ * - Team switching happens ONLY through the pill/sheet
+ * 
+ * This screen is kept for:
+ * - Deep links (e.g., notifications that link directly to team)
+ * - Backward compatibility during transition
+ * - Rare/advanced team views that don't fit in the main tab
+ * 
+ * PRIMARY USER FLOW should use:
+ * - Team Tab → Calendar (scheduled sessions for activeTeamId)
+ * - Team Tab → Manage (members, settings, library for activeTeamId)
+ * 
+ * ═══════════════════════════════════════════════════════════════════════════
  * OWNERSHIP CONTRACT (DO NOT VIOLATE)
  * ═══════════════════════════════════════════════════════════════════════════
  * 

--- a/components/home/unified/sections/TeamsRow.tsx
+++ b/components/home/unified/sections/TeamsRow.tsx
@@ -12,10 +12,11 @@ export function TeamsRow({ colors }: { colors: ReturnType<typeof useColors> }) {
 
   if (teams.length === 0) return null;
 
-  // Navigate to team workspace (sets active team first)
+  // Navigate to Team tab (unified workspace) - sets active team first
+  // Note: teamWorkspace is deprecated; Team tab IS the team workspace
   const handleTeamPress = (teamId: string) => {
     setActiveTeam(teamId);
-    router.push(`/(protected)/teamWorkspace?id=${teamId}` as any);
+    router.push('/(protected)/(tabs)/trainings' as any);
   };
 
   // Single team - show expanded card

--- a/docs/data-flow-map.md
+++ b/docs/data-flow-map.md
@@ -97,9 +97,27 @@ flowchart TD
 
 ### Active team + members (RPC + fallback select)
 
+> **Note:** As of the Unified Team Tab update, `teamWorkspace.tsx` is deprecated.
+> The Team Tab (`trainings.tsx`) IS the team workspace when an activeTeam is selected.
+> Team switching happens only through the pill/sheet - no separate "team page" navigation.
+
 ```mermaid
 flowchart TD
-  TeamWorkspace[app_protected_teamWorkspace] --> teamStoreActive[store_teamStore_loadActiveTeam]
+  TeamTab[app_protected_tabs_trainings] --> teamStoreLoad[store_teamStore_loadTeams]
+  teamStoreLoad --> rpcGetMyTeams[services_teamService_getMyTeams]
+  rpcGetMyTeams --> rpc[(rpc_get_my_teams)]
+  
+  TeamTab --> teamMembers[app_protected_teamMembers]
+  teamMembers --> getTeamMembers[services_teamService_getTeamMembers]
+  getTeamMembers --> teamMembersTable[(team_members)]
+  teamMembersTable --> profiles[(profiles)]
+```
+
+### Legacy: Team Workspace (deprecated)
+
+```mermaid
+flowchart TD
+  TeamWorkspace[app_protected_teamWorkspace_DEPRECATED] --> teamStoreActive[store_teamStore_loadActiveTeam]
   teamStoreActive --> rpcTeamWithMembers[services_teamService_getTeamWithMembers]
   rpcTeamWithMembers --> rpc[(rpc_get_team_with_members)]
   rpcTeamWithMembers -->|fallback_when_profiles_incomplete| teamMembers[(team_members)]


### PR DESCRIPTION
Unify the Team tab as the primary team workspace to eliminate a confusing "manage → manage again" UX flow.

This PR consolidates team management and content (members, settings, drill library) directly into the Team tab, deprecating the separate `teamWorkspace.tsx` page. The goal is to ensure that when an active team is selected via the header pill, the Team tab immediately reflects that team's content without requiring an additional navigation step.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f10446c-378b-4a5d-8cd5-ba56dffdfe86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f10446c-378b-4a5d-8cd5-ba56dffdfe86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

