### PR TITLE
fix: show only real upcoming trainings in dashboard widget

### DIFF
--- a/hooks/home/useTeamHomePage.ts
+++ b/hooks/home/useTeamHomePage.ts
@@ -21,7 +21,7 @@ import { useGarminStore } from '@/stores/garminStore';
 import { useTeamStore } from '@/stores/teamStore';
 import { useTrainingStore } from '@/stores/trainingStore';
 import type { WeeklyStats } from '@/types/home';
-import { mapSessionToHomeSession } from '@/types/home.viewmodel';
+import { mapSessionToHomeSession, mapTrainingToScheduledSession } from '@/types/home.viewmodel';
 import type { SessionWithDetails } from '@/types/session';
 import type { TeamMemberWithProfile, TrainingWithDetails } from '@/types/workspace';
 import { isGroupingSessionWithFallback } from '@/utils/drillGoal';
@@ -288,6 +288,14 @@ export function useTeamHomePage() {
     };
   }, [upcomingTrainings, activeTeam?.name]);
 
+  // Upcoming trainings for the widget's "UPCOMING" list — real planned/ongoing
+  // trainings only (never completed sessions). These feed the dashboard widget
+  // after activeSession/nextSession are placed.
+  const upcomingSessionsForWidget = useMemo(
+    () => teamTrainings.slice(0, 5).map((t) => mapTrainingToScheduledSession(t)),
+    [teamTrainings]
+  );
+
   useEffect(() => {
     void syncHomeWidgets({
       activeSession: activeSessionForWidget,
@@ -295,8 +303,9 @@ export function useTeamHomePage() {
       weeklyStats,
       streak,
       recentSessions: recentHomeSessions,
+      upcomingSessions: upcomingSessionsForWidget,
     });
-  }, [activeSessionForWidget, nextSessionForWidget, weeklyStats, streak, recentHomeSessions]);
+  }, [activeSessionForWidget, nextSessionForWidget, weeklyStats, streak, recentHomeSessions, upcomingSessionsForWidget]);
 
   // Loading state - wait for all data including activeTeam details
   const shouldShowLoading =

--- a/hooks/home/useUnifiedHomePage.ts
+++ b/hooks/home/useUnifiedHomePage.ts
@@ -28,7 +28,7 @@ import { useSessionStore } from '@/stores/sessionStore';
 import { useTeamStore } from '@/stores/teamStore';
 import { useTrainingStore } from '@/stores/trainingStore';
 import type { HeroMode, WeeklyStats } from '@/types/home';
-import { mapSessionToHomeSession, type HomeSession } from '@/types/home.viewmodel';
+import { mapSessionToHomeSession, mapTrainingToScheduledSession, type HomeSession } from '@/types/home.viewmodel';
 import type { SessionWithDetails } from '@/types/session';
 import {
     calculateLastSessionDaysAgo,
@@ -326,12 +326,22 @@ export function useUnifiedHomePage() {
     (loadingAllSessions && allSessions.length === 0) ||
     (!initialized && sessionsLoading);
 
+  // Upcoming trainings for the widget's "UPCOMING" list — only real planned/
+  // ongoing trainings. We pull from `allTeamsUpcoming` (already filtered to
+  // status=planned|ongoing and sorted by date) so the widget reflects upcoming
+  // activity regardless of whether the user is in personal or team mode.
+  const upcomingSessionsForWidget = useMemo(
+    () => allTeamsUpcoming.slice(0, 5).map((t) => mapTrainingToScheduledSession(t)),
+    [allTeamsUpcoming]
+  );
+
   useWidgetSync({
     activeSession: homeState.activeSession,
     nextSession: homeState.nextSession,
     weeklyStats,
     streak,
     recentSessions,
+    upcomingSessions: upcomingSessionsForWidget,
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/hooks/useWidgetSync.ts
+++ b/hooks/useWidgetSync.ts
@@ -10,6 +10,7 @@ interface UseWidgetSyncParams {
   weeklyStats: WeeklyStats;
   streak: number;
   recentSessions: HomeSession[];
+  upcomingSessions: HomeSession[];
 }
 
 export function useWidgetSync({
@@ -18,6 +19,7 @@ export function useWidgetSync({
   weeklyStats,
   streak,
   recentSessions,
+  upcomingSessions,
 }: UseWidgetSyncParams) {
   useEffect(() => {
     if (__DEV__) {
@@ -27,6 +29,7 @@ export function useWidgetSync({
         weeklyAccuracy: weeklyStats?.accuracy,
         streak,
         recentCount: recentSessions.length,
+        upcomingCount: upcomingSessions.length,
       });
     }
     void syncHomeWidgets({
@@ -35,6 +38,7 @@ export function useWidgetSync({
       weeklyStats,
       streak,
       recentSessions,
+      upcomingSessions,
     });
-  }, [activeSession, nextSession, weeklyStats, streak, recentSessions]);
+  }, [activeSession, nextSession, weeklyStats, streak, recentSessions, upcomingSessions]);
 }

--- a/services/widgets/widgetSyncService.ts
+++ b/services/widgets/widgetSyncService.ts
@@ -250,7 +250,7 @@ const toDashboardRowState = (
 const buildDashboardItems = (params: {
   activeSession: HomeSession | null;
   nextSession: HomeSession | null;
-  recentSessions: HomeSession[];
+  upcomingSessions: HomeSession[];
 }): DashboardTrainingItem[] => {
   const collected: DashboardTrainingItem[] = [];
   const pushed = new Set<string>();
@@ -267,9 +267,13 @@ const buildDashboardItems = (params: {
     });
   };
 
+  // The widget's "UPCOMING" section must only contain upcoming items
+  // (live/active, next scheduled, and remaining planned trainings). Completed
+  // sessions are intentionally excluded here — the weekly KPI strip already
+  // reflects completed activity.
   push(params.activeSession);
   push(params.nextSession);
-  for (const s of params.recentSessions) {
+  for (const s of params.upcomingSessions) {
     if (collected.length >= 3) break;
     push(s);
   }
@@ -282,6 +286,7 @@ function buildRealPayloads(params: {
   weeklyStats: WeeklyStats;
   streak: number;
   recentSessions: HomeSession[];
+  upcomingSessions: HomeSession[];
 }): {
   today: TodayTrainingWidgetProps;
   performance: PerformanceSnapshotWidgetProps;
@@ -310,7 +315,11 @@ function buildRealPayloads(params: {
     hasData: hasPerformanceData,
   };
 
-  const items = buildDashboardItems(params);
+  const items = buildDashboardItems({
+    activeSession: params.activeSession,
+    nextSession: params.nextSession,
+    upcomingSessions: params.upcomingSessions,
+  });
   const dashboard: TrainingDashboardWidgetProps = {
     trainings: items,
     weeklySessions: Math.max(0, Math.round(params.weeklyStats.sessions ?? 0)),
@@ -382,7 +391,10 @@ export async function syncHomeWidgets(params: {
   nextSession: HomeSession | null;
   weeklyStats: WeeklyStats;
   streak: number;
+  /** Completed/unreviewed sessions — used for lastScore on the perf widget. */
   recentSessions: HomeSession[];
+  /** Planned/ongoing trainings — populates the dashboard UPCOMING list. */
+  upcomingSessions: HomeSession[];
 }): Promise<void> {
   if (!canUseWidgets()) {
     wlog('syncHomeWidgets: not iOS, skipping');


### PR DESCRIPTION
The TrainingDashboardWidget's "UPCOMING" section was pulling from
recentSessions (all completed/unreviewed) to fill empty slots, causing
completed practices to appear under an "UPCOMING" header — inconsistent
with the home screen, which only lists planned/ongoing trainings.

Split the data source: recentSessions is still used for the performance
widget's lastScore, while a new upcomingSessions param feeds the
dashboard list with mapped planned/ongoing trainings only.

https://claude.ai/code/session_01Hdyk1QroXjRjt6pfUbKBrv