### PR TITLE
feat(team): add team performance PDF report generator

### DIFF
--- a/app/(protected)/(tabs)/team.tsx
+++ b/app/(protected)/(tabs)/team.tsx
@@ -22,6 +22,7 @@ import {
     BarChart3,
     ChevronRight,
     Clock,
+    FileText,
     LogOut,
     Settings,
     Shield,
@@ -417,6 +418,23 @@ function TeamTabContent({
                 iconBg={colors.green + '12'}
                 label="Invite Member"
                 onPress={onInviteMember}
+                colors={colors}
+              />
+            </>
+          )}
+
+          {/* Generate Report - commander only */}
+          {canManage && (
+            <>
+              <View style={[ts.menuDivider, { backgroundColor: colors.border }]} />
+              <MenuItem
+                icon={<FileText size={15} color={colors.indigo} />}
+                iconBg={colors.indigo + '18'}
+                label={t('teams.generateReport')}
+                onPress={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  router.push(`/(protected)/generateTeamReport?teamId=${activeTeamId ?? ''}&teamName=${encodeURIComponent(activeTeam?.name ?? '')}` as any);
+                }}
                 colors={colors}
               />
             </>

--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -319,6 +319,20 @@ export default function ProtectedLayout() {
           contentStyle: { backgroundColor: colors.background },
         }}
       />
+
+      <Stack.Screen
+        name="generateTeamReport"
+        options={{
+          headerShown: false,
+          presentation: 'formSheet',
+          gestureEnabled: true,
+          sheetGrabberVisible: true,
+          contentStyle: { backgroundColor: colors.card },
+          sheetAllowedDetents: [0.55, 0.85],
+          sheetInitialDetentIndex: 0,
+          sheetLargestUndimmedDetentIndex: -1,
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(protected)/generateTeamReport.tsx
+++ b/app/(protected)/generateTeamReport.tsx
@@ -1,0 +1,277 @@
+/**
+ * Generate Team Report – Form Sheet
+ *
+ * Lets a commander pick a date range then generate + share a PDF report.
+ */
+
+import { useColors } from '@/hooks/ui/useColors';
+import { fetchTeamReportData, shareTeamReportPDF } from '@/services/report/teamReport';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { subDays } from 'date-fns';
+import * as Haptics from 'expo-haptics';
+import { router, useLocalSearchParams } from 'expo-router';
+import { FileText } from 'lucide-react-native';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type Mode = 'idle' | 'generating' | 'error';
+
+export default function GenerateTeamReport() {
+  const colors = useColors();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+  const { teamId, teamName } = useLocalSearchParams<{ teamId: string; teamName?: string }>();
+
+  const [startDate, setStartDate] = useState<Date>(() => subDays(new Date(), 30));
+  const [endDate, setEndDate] = useState<Date>(() => new Date());
+  const [showStartPicker, setShowStartPicker] = useState(false);
+  const [showEndPicker, setShowEndPicker] = useState(false);
+  const [mode, setMode] = useState<Mode>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const resolvedTeamName = teamName ?? t('teams.title');
+
+  async function handleGenerate() {
+    if (!teamId) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setMode('generating');
+    setErrorMsg('');
+    try {
+      const data = await fetchTeamReportData({
+        teamId,
+        teamName: resolvedTeamName,
+        startDate,
+        endDate,
+      });
+      await shareTeamReportPDF(data);
+      router.back();
+    } catch (err: any) {
+      setErrorMsg(err?.message ?? t('teams.reportGenerationFailed'));
+      setMode('error');
+    }
+  }
+
+  function formatDate(d: Date): string {
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  return (
+    <ScrollView
+      style={[styles.scroll, { backgroundColor: colors.card }]}
+      contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 40 }]}
+      keyboardShouldPersistTaps="handled"
+    >
+      {/* Handle */}
+      <View style={[styles.handle, { backgroundColor: colors.border }]} />
+
+      {/* Header */}
+      <View style={styles.header}>
+        <View style={[styles.headerIcon, { backgroundColor: colors.indigo + '18' }]}>
+          <FileText size={26} color={colors.indigo} />
+        </View>
+        <Text style={[styles.title, { color: colors.text }]}>{t('teams.generateTeamReport')}</Text>
+        <Text style={[styles.subtitle, { color: colors.textMuted }]}>{resolvedTeamName}</Text>
+      </View>
+
+      {/* Date Range Section */}
+      <View style={styles.section}>
+        <Text style={[styles.sectionLabel, { color: colors.textMuted }]}>
+          {t('teams.reportDateRange').toUpperCase()}
+        </Text>
+        <View style={[styles.card, { backgroundColor: colors.background, borderColor: colors.border }]}>
+          {/* Start Date */}
+          <TouchableOpacity
+            style={styles.dateRow}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              setShowStartPicker(true);
+            }}
+            activeOpacity={0.7}
+          >
+            <Text style={[styles.dateLabel, { color: colors.textMuted }]}>{t('teams.reportStartDate')}</Text>
+            <Text style={[styles.dateValue, { color: colors.text }]}>{formatDate(startDate)}</Text>
+          </TouchableOpacity>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          {/* End Date */}
+          <TouchableOpacity
+            style={styles.dateRow}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              setShowEndPicker(true);
+            }}
+            activeOpacity={0.7}
+          >
+            <Text style={[styles.dateLabel, { color: colors.textMuted }]}>{t('teams.reportEndDate')}</Text>
+            <Text style={[styles.dateValue, { color: colors.text }]}>{formatDate(endDate)}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* CTA */}
+      <TouchableOpacity
+        style={[
+          styles.cta,
+          { backgroundColor: colors.indigo },
+          mode === 'generating' && styles.ctaDisabled,
+        ]}
+        onPress={handleGenerate}
+        disabled={mode === 'generating'}
+        activeOpacity={0.85}
+      >
+        {mode === 'generating' ? (
+          <View style={styles.ctaRow}>
+            <ActivityIndicator size="small" color="#fff" style={{ marginRight: 8 }} />
+            <Text style={styles.ctaText}>{t('teams.generatingReport')}</Text>
+          </View>
+        ) : (
+          <Text style={styles.ctaText}>{t('teams.generatePdf')}</Text>
+        )}
+      </TouchableOpacity>
+
+      {mode === 'error' && (
+        <Text style={[styles.errorText, { color: '#DC2626' }]}>{errorMsg}</Text>
+      )}
+
+      {/* Start Date Picker Modal */}
+      <PickerModal
+        visible={showStartPicker}
+        onClose={() => setShowStartPicker(false)}
+        title={t('teams.reportStartDate')}
+        value={startDate}
+        onChange={(d) => setStartDate(d)}
+        maximumDate={endDate}
+        colors={colors}
+        bottomInset={insets.bottom}
+      />
+
+      {/* End Date Picker Modal */}
+      <PickerModal
+        visible={showEndPicker}
+        onClose={() => setShowEndPicker(false)}
+        title={t('teams.reportEndDate')}
+        value={endDate}
+        onChange={(d) => setEndDate(d)}
+        minimumDate={startDate}
+        maximumDate={new Date()}
+        colors={colors}
+        bottomInset={insets.bottom}
+      />
+    </ScrollView>
+  );
+}
+
+// ============================================================================
+// PICKER MODAL (matches createTraining.tsx pattern)
+// ============================================================================
+
+function PickerModal({
+  visible,
+  onClose,
+  title,
+  value,
+  onChange,
+  minimumDate,
+  maximumDate,
+  colors,
+  bottomInset,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  value: Date;
+  onChange: (date: Date) => void;
+  minimumDate?: Date;
+  maximumDate?: Date;
+  colors: ReturnType<typeof useColors>;
+  bottomInset: number;
+}) {
+  const { t } = useTranslation();
+  if (!visible) return null;
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.pickerOverlay} onPress={onClose}>
+        <Pressable style={[styles.pickerSheet, { backgroundColor: colors.card }]} onPress={(e) => e.stopPropagation()}>
+          <View style={[styles.pickerHandle, { backgroundColor: colors.border }]} />
+          <View style={styles.pickerHeader}>
+            <TouchableOpacity onPress={onClose} style={styles.pickerHeaderBtn} hitSlop={8}>
+              <Text style={[styles.pickerCancel, { color: colors.textMuted }]}>{t('common.cancel')}</Text>
+            </TouchableOpacity>
+            <Text style={[styles.pickerTitle, { color: colors.text }]}>{title}</Text>
+            <TouchableOpacity onPress={onClose} style={styles.pickerHeaderBtn} hitSlop={8}>
+              <Text style={[styles.pickerDone, { color: colors.primary }]}>{t('common.done')}</Text>
+            </TouchableOpacity>
+          </View>
+          <View style={[styles.pickerDivider, { backgroundColor: colors.border }]} />
+          <DateTimePicker
+            value={value}
+            mode="date"
+            display="spinner"
+            onChange={(_, date) => date && onChange(date)}
+            minimumDate={minimumDate}
+            maximumDate={maximumDate}
+            style={styles.picker}
+          />
+          <View style={{ height: bottomInset + 8 }} />
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+// ============================================================================
+// STYLES
+// ============================================================================
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  content: { paddingHorizontal: 20, paddingTop: 8 },
+
+  handle: { width: 32, height: 4, borderRadius: 2, alignSelf: 'center', marginTop: 4, marginBottom: 16 },
+
+  header: { alignItems: 'center', paddingBottom: 28 },
+  headerIcon: { width: 60, height: 60, borderRadius: 16, alignItems: 'center', justifyContent: 'center', marginBottom: 12 },
+  title: { fontSize: 20, fontWeight: '700', letterSpacing: -0.4, textAlign: 'center' },
+  subtitle: { fontSize: 14, marginTop: 4, textAlign: 'center' },
+
+  section: { marginBottom: 20 },
+  sectionLabel: { fontSize: 11, fontWeight: '600', letterSpacing: 0.08, marginBottom: 8 },
+
+  card: { borderRadius: 12, borderWidth: 1, overflow: 'hidden' },
+  dateRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 14 },
+  dateLabel: { fontSize: 14 },
+  dateValue: { fontSize: 14, fontWeight: '600' },
+  divider: { height: 1, marginHorizontal: 16 },
+
+  cta: { borderRadius: 14, paddingVertical: 16, alignItems: 'center', marginTop: 4 },
+  ctaDisabled: { opacity: 0.6 },
+  ctaRow: { flexDirection: 'row', alignItems: 'center' },
+  ctaText: { color: '#fff', fontSize: 16, fontWeight: '700', letterSpacing: -0.2 },
+
+  errorText: { fontSize: 13, textAlign: 'center', marginTop: 12 },
+
+  // Picker modal
+  pickerOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  pickerSheet: { borderTopLeftRadius: 16, borderTopRightRadius: 16 },
+  pickerHandle: { width: 32, height: 4, borderRadius: 2, alignSelf: 'center', marginTop: 10, marginBottom: 6 },
+  pickerHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, height: 44 },
+  pickerHeaderBtn: { minWidth: 60 },
+  pickerCancel: { fontSize: 15, fontWeight: '500' },
+  pickerTitle: { fontSize: 15, fontWeight: '600', letterSpacing: -0.2 },
+  pickerDone: { fontSize: 15, fontWeight: '600', textAlign: 'right' },
+  pickerDivider: { height: 1, marginHorizontal: 16 },
+  picker: { height: 180 },
+});

--- a/services/i18n-locales/en.json
+++ b/services/i18n-locales/en.json
@@ -1064,7 +1064,21 @@
     "failedUpdateSquads": "Failed to update squads. Please try again.",
     "failedAssignMember": "Failed to assign member to squad.",
     "removeFromSquadTitle": "Remove from Squad",
-    "removeFromSquadConfirm": "Remove this soldier from the squad?"
+    "removeFromSquadConfirm": "Remove this soldier from the squad?",
+    "generateReport": "Generate Report",
+    "teamReport": "Team Report",
+    "generateTeamReport": "Generate Team Report",
+    "reportDateRange": "Date Range",
+    "reportStartDate": "Start Date",
+    "reportEndDate": "End Date",
+    "generatePdf": "Generate PDF",
+    "generatingReport": "Generating report…",
+    "reportGenerationFailed": "Could not generate report",
+    "reportNoData": "No activity in this date range",
+    "reportSectionGrouping": "Grouping Performance",
+    "reportSectionAccuracy": "Hit Accuracy",
+    "reportSectionWeapons": "Weapons",
+    "reportSectionSpotter": "Spotter Performance"
   },
   "account": {
     "personal": "Personal",

--- a/services/i18n-locales/he.json
+++ b/services/i18n-locales/he.json
@@ -1057,7 +1057,21 @@
     "failedUpdateSquads": "עדכון הכיתות נכשל. אנא נסה שוב.",
     "failedAssignMember": "הקצאת החבר לחוליה נכשלה.",
     "removeFromSquadTitle": "הסר מחוליה",
-    "removeFromSquadConfirm": "הסר את החייל הזה מהחוליה?"
+    "removeFromSquadConfirm": "הסר את החייל הזה מהחוליה?",
+    "generateReport": "צור דוח",
+    "teamReport": "דוח צוות",
+    "generateTeamReport": "צור דוח ביצועי צוות",
+    "reportDateRange": "טווח תאריכים",
+    "reportStartDate": "תאריך התחלה",
+    "reportEndDate": "תאריך סיום",
+    "generatePdf": "צור PDF",
+    "generatingReport": "יוצר דוח…",
+    "reportGenerationFailed": "לא ניתן היה ליצור דוח",
+    "reportNoData": "אין פעילות בטווח תאריכים זה",
+    "reportSectionGrouping": "ביצועי קיבוץ",
+    "reportSectionAccuracy": "דיוק פגיעות",
+    "reportSectionWeapons": "נשק",
+    "reportSectionSpotter": "ביצועי מכוון"
   },
   "account": {
     "personal": "אישי",

--- a/services/report/teamReport.ts
+++ b/services/report/teamReport.ts
@@ -1,0 +1,636 @@
+/**
+ * Team Performance Report
+ *
+ * Fetches team session data, aggregates per-user stats across positions,
+ * weapons, and spotter roles, then generates and shares a PDF report.
+ */
+
+import { SESSION_SELECT_WITH_FULL_DRILL, TARGET_STATS_SELECT } from '@/services/session/selectClauses';
+import { mapSession } from '@/services/session/mappers';
+import { getTeamMembers } from '@/services/teamService';
+import { supabase } from '@/services/supabase';
+import type { SessionWithDetails } from '@/types/session';
+import { format } from 'date-fns';
+import * as Print from 'expo-print';
+import * as Sharing from 'expo-sharing';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+type PositionKey = 'prone' | 'sitting' | 'standing' | 'kneeling' | 'other';
+
+interface PositionGroupingStats {
+  sessions: number;
+  bestCm: number | null;
+  avgCm: number | null;
+  _totalCm: number;
+  _countCm: number;
+}
+
+interface PositionAccuracyStats {
+  sessions: number;
+  shots: number;
+  hits: number;
+  pct: number;
+}
+
+interface TimeLimitBucket {
+  sessions: number;
+  shots: number;
+  hits: number;
+  pct: number;
+}
+
+interface WeaponBucket {
+  sessions: number;
+  shots: number;
+  hits: number;
+  pct: number;
+}
+
+interface SpotterStats {
+  engagements: number;
+  shotsObserved: number;
+  hitsObserved: number;
+  hitPct: number;
+  firstShotHits: number;
+  firstShotTotal: number;
+  firstShotPct: number;
+}
+
+export interface UserReportData {
+  userId: string;
+  userName: string;
+  role: string;
+  totals: { sessions: number; shots: number; hits: number; accuracy: number };
+  grouping: Record<PositionKey, PositionGroupingStats>;
+  hitAccuracy: Record<PositionKey, PositionAccuracyStats>;
+  timeLimit: {
+    withTimeLimit: TimeLimitBucket;
+    noTimeLimit: TimeLimitBucket;
+  };
+  byWeapon: Record<string, WeaponBucket>;
+  spotter: SpotterStats;
+}
+
+export interface TeamReportData {
+  team: { id: string; name: string };
+  dateRange: { start: Date; end: Date };
+  generatedAt: Date;
+  users: UserReportData[];
+  summary: { members: number; sessions: number; shots: number; hits: number; accuracy: number };
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+const POSITIONS: PositionKey[] = ['prone', 'sitting', 'standing', 'kneeling', 'other'];
+
+function emptyGroupingStats(): PositionGroupingStats {
+  return { sessions: 0, bestCm: null, avgCm: null, _totalCm: 0, _countCm: 0 };
+}
+
+function emptyAccuracyStats(): PositionAccuracyStats {
+  return { sessions: 0, shots: 0, hits: 0, pct: 0 };
+}
+
+function emptyTimeLimitBucket(): TimeLimitBucket {
+  return { sessions: 0, shots: 0, hits: 0, pct: 0 };
+}
+
+function emptySpotter(): SpotterStats {
+  return { engagements: 0, shotsObserved: 0, hitsObserved: 0, hitPct: 0, firstShotHits: 0, firstShotTotal: 0, firstShotPct: 0 };
+}
+
+function emptyUserData(userId: string, userName: string, role: string): UserReportData {
+  const grouping = Object.fromEntries(POSITIONS.map((p) => [p, emptyGroupingStats()])) as Record<PositionKey, PositionGroupingStats>;
+  const hitAccuracy = Object.fromEntries(POSITIONS.map((p) => [p, emptyAccuracyStats()])) as Record<PositionKey, PositionAccuracyStats>;
+  return {
+    userId,
+    userName,
+    role,
+    totals: { sessions: 0, shots: 0, hits: 0, accuracy: 0 },
+    grouping,
+    hitAccuracy,
+    timeLimit: { withTimeLimit: emptyTimeLimitBucket(), noTimeLimit: emptyTimeLimitBucket() },
+    byWeapon: {},
+    spotter: emptySpotter(),
+  };
+}
+
+function normalizePosition(raw: string | null | undefined): PositionKey {
+  if (!raw) return 'other';
+  const lower = raw.toLowerCase();
+  if (lower === 'prone') return 'prone';
+  if (lower === 'sitting' || lower === 'seated') return 'sitting';
+  if (lower === 'standing') return 'standing';
+  if (lower === 'kneeling') return 'kneeling';
+  return 'other';
+}
+
+function finalizePct(bucket: { shots: number; hits: number; pct: number }): void {
+  bucket.pct = bucket.shots > 0 ? Math.round((bucket.hits / bucket.shots) * 100) : 0;
+}
+
+function finalizeGroupingAvg(gs: PositionGroupingStats): void {
+  gs.avgCm = gs._countCm > 0 ? Math.round((gs._totalCm / gs._countCm) * 10) / 10 : null;
+}
+
+// ============================================================================
+// FETCH
+// ============================================================================
+
+export async function fetchTeamReportData(params: {
+  teamId: string;
+  teamName: string;
+  startDate: Date;
+  endDate: Date;
+}): Promise<TeamReportData> {
+  const { teamId, teamName, startDate, endDate } = params;
+
+  // 1. Fetch completed sessions in date range
+  const { data: sessionsRaw, error: sessionsError } = await supabase
+    .from('sessions')
+    .select(SESSION_SELECT_WITH_FULL_DRILL)
+    .eq('team_id', teamId)
+    .eq('status', 'completed')
+    .gte('started_at', startDate.toISOString())
+    .lte('started_at', endDate.toISOString())
+    .order('started_at', { ascending: true });
+
+  if (sessionsError) throw new Error(sessionsError.message);
+
+  const sessions: SessionWithDetails[] = (sessionsRaw ?? []).map(mapSession);
+
+  // 2. Batch fetch session_targets stats
+  const sessionIds = sessions.map((s) => s.id);
+  let statsMap = new Map<string, { shots: number; hits: number; bestDispersionCm: number | null; firstShotHit: boolean | null }[]>();
+
+  if (sessionIds.length > 0) {
+    const { data: targetsRaw, error: targetsError } = await supabase
+      .from('session_targets')
+      .select(TARGET_STATS_SELECT)
+      .in('session_id', sessionIds);
+
+    if (targetsError) {
+      console.error('[teamReport] Failed to fetch session_targets:', targetsError);
+    } else {
+      for (const row of targetsRaw ?? []) {
+        const sid = row.session_id as string;
+        if (!statsMap.has(sid)) statsMap.set(sid, []);
+        const arr = statsMap.get(sid)!;
+
+        if (row.paper_target_results) {
+          const p = row.paper_target_results as any;
+          arr.push({
+            shots: p.bullets_fired ?? 0,
+            hits: p.hits_total ?? 0,
+            bestDispersionCm: p.dispersion_cm ?? null,
+            firstShotHit: null,
+          });
+        }
+        if (row.tactical_target_results) {
+          const t = row.tactical_target_results as any;
+          arr.push({
+            shots: t.bullets_fired ?? 0,
+            hits: t.hits ?? 0,
+            bestDispersionCm: null,
+            firstShotHit: t.first_shot_hit ?? null,
+          });
+        }
+      }
+    }
+  }
+
+  // 3. Fetch team members (to include zero-activity users)
+  const members = await getTeamMembers(teamId);
+  const memberMap = new Map(members.map((m) => [m.user_id, m]));
+
+  // 4. Build per-user data map, seeded with all known members
+  const userMap = new Map<string, UserReportData>();
+  for (const m of members) {
+    const name = (m.profile as any)?.full_name ?? 'Unknown';
+    const role = (m.role as any)?.role ?? 'soldier';
+    userMap.set(m.user_id, emptyUserData(m.user_id, name, role));
+  }
+
+  // 5. Aggregate sessions into per-user buckets
+  for (const session of sessions) {
+    const uid = session.user_id;
+
+    // Seed map for users not in team_members (e.g. removed members who still have sessions)
+    if (!userMap.has(uid)) {
+      const name = session.user_full_name ?? 'Unknown';
+      const member = memberMap.get(uid);
+      const role = (member?.role as any)?.role ?? 'soldier';
+      userMap.set(uid, emptyUserData(uid, name, role));
+    }
+
+    const ud = userMap.get(uid)!;
+    const dc = session.drill_config;
+    const isGrouping = dc?.drill_goal === 'grouping';
+    const position = normalizePosition(dc?.position ?? session.soldier_position);
+    const hasTimeLimit = (dc?.time_limit_seconds ?? null) !== null;
+    const weaponName = session.weapon_name ?? 'Unknown';
+
+    // Session-level stats from session_targets
+    const targets = statsMap.get(session.id) ?? [];
+    let sessionShots = 0;
+    let sessionHits = 0;
+    let sessionBestCm: number | null = null;
+    let sessionFirstShotHit: boolean | null = null;
+
+    for (const t of targets) {
+      sessionShots += t.shots;
+      sessionHits += t.hits;
+      if (t.bestDispersionCm !== null) {
+        if (sessionBestCm === null || t.bestDispersionCm < sessionBestCm) {
+          sessionBestCm = t.bestDispersionCm;
+        }
+      }
+      if (t.firstShotHit !== null) sessionFirstShotHit = t.firstShotHit;
+    }
+
+    // Fall back to engagement_participants stats for squad/group sessions
+    const engagement = session.engagement;
+    if (engagement) {
+      const myParticipation = engagement.engagement_participants?.find(
+        (p: any) => p.user_id === uid
+      );
+      if (myParticipation) {
+        const pRole = myParticipation.role;
+        if (pRole === 'spotter') {
+          // Spotter stats
+          ud.spotter.engagements++;
+          ud.spotter.shotsObserved += myParticipation.shots_fired ?? 0;
+          ud.spotter.hitsObserved += myParticipation.hits ?? 0;
+          if (sessionFirstShotHit !== null) {
+            ud.spotter.firstShotTotal++;
+            if (sessionFirstShotHit) ud.spotter.firstShotHits++;
+          }
+          // Spotter doesn't count as a shooter session
+          continue;
+        }
+        // Shooter in engagement — use participant counts if available
+        if ((myParticipation.shots_fired ?? 0) > 0 || (myParticipation.hits ?? 0) > 0) {
+          sessionShots = myParticipation.shots_fired ?? sessionShots;
+          sessionHits = myParticipation.hits ?? sessionHits;
+        }
+      }
+    }
+
+    // Totals
+    ud.totals.sessions++;
+    ud.totals.shots += sessionShots;
+    ud.totals.hits += sessionHits;
+
+    // Grouping
+    if (isGrouping) {
+      const gs = ud.grouping[position];
+      gs.sessions++;
+      if (sessionBestCm !== null) {
+        if (gs.bestCm === null || sessionBestCm < gs.bestCm) gs.bestCm = sessionBestCm;
+        gs._totalCm += sessionBestCm;
+        gs._countCm++;
+      }
+    } else {
+      // Hit accuracy by position
+      const as_ = ud.hitAccuracy[position];
+      as_.sessions++;
+      as_.shots += sessionShots;
+      as_.hits += sessionHits;
+    }
+
+    // Time-limit bucket
+    const bucket = hasTimeLimit ? ud.timeLimit.withTimeLimit : ud.timeLimit.noTimeLimit;
+    bucket.sessions++;
+    bucket.shots += sessionShots;
+    bucket.hits += sessionHits;
+
+    // Weapon bucket
+    if (!ud.byWeapon[weaponName]) ud.byWeapon[weaponName] = { sessions: 0, shots: 0, hits: 0, pct: 0 };
+    ud.byWeapon[weaponName].sessions++;
+    ud.byWeapon[weaponName].shots += sessionShots;
+    ud.byWeapon[weaponName].hits += sessionHits;
+  }
+
+  // 6. Finalize computed fields
+  for (const ud of userMap.values()) {
+    ud.totals.accuracy = ud.totals.shots > 0 ? Math.round((ud.totals.hits / ud.totals.shots) * 100) : 0;
+    for (const pos of POSITIONS) {
+      finalizeGroupingAvg(ud.grouping[pos]);
+      finalizePct(ud.hitAccuracy[pos]);
+    }
+    finalizePct(ud.timeLimit.withTimeLimit);
+    finalizePct(ud.timeLimit.noTimeLimit);
+    for (const wb of Object.values(ud.byWeapon)) finalizePct(wb);
+    const sp = ud.spotter;
+    sp.hitPct = sp.shotsObserved > 0 ? Math.round((sp.hitsObserved / sp.shotsObserved) * 100) : 0;
+    sp.firstShotPct = sp.firstShotTotal > 0 ? Math.round((sp.firstShotHits / sp.firstShotTotal) * 100) : 0;
+  }
+
+  const users = Array.from(userMap.values()).sort((a, b) => b.totals.sessions - a.totals.sessions);
+
+  // 7. Summary
+  const totalSessions = sessions.length;
+  const totalShots = users.reduce((s, u) => s + u.totals.shots, 0);
+  const totalHits = users.reduce((s, u) => s + u.totals.hits, 0);
+
+  return {
+    team: { id: teamId, name: teamName },
+    dateRange: { start: startDate, end: endDate },
+    generatedAt: new Date(),
+    users,
+    summary: {
+      members: members.length,
+      sessions: totalSessions,
+      shots: totalShots,
+      hits: totalHits,
+      accuracy: totalShots > 0 ? Math.round((totalHits / totalShots) * 100) : 0,
+    },
+  };
+}
+
+// ============================================================================
+// HTML TEMPLATE
+// ============================================================================
+
+const ACCENT = '#5B6B8C';
+
+function pct(value: number): string {
+  return `${value}%`;
+}
+
+function cm(value: number | null): string {
+  return value !== null ? `${value.toFixed(1)} cm` : '—';
+}
+
+function renderGroupingTable(grouping: Record<PositionKey, PositionGroupingStats>): string {
+  const rows = POSITIONS.filter((p) => grouping[p].sessions > 0);
+  if (rows.length === 0) return '<p class="no-data">No grouping data</p>';
+  return `
+    <table>
+      <thead><tr><th>Position</th><th>Sessions</th><th>Best Group</th><th>Avg Group</th></tr></thead>
+      <tbody>
+        ${rows.map((p) => {
+          const g = grouping[p];
+          return `<tr>
+            <td style="text-transform:capitalize">${p}</td>
+            <td>${g.sessions}</td>
+            <td>${cm(g.bestCm)}</td>
+            <td>${cm(g.avgCm)}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>`;
+}
+
+function renderAccuracyTable(hitAccuracy: Record<PositionKey, PositionAccuracyStats>): string {
+  const rows = POSITIONS.filter((p) => hitAccuracy[p].sessions > 0);
+  if (rows.length === 0) return '<p class="no-data">No hit accuracy data</p>';
+  return `
+    <table>
+      <thead><tr><th>Position</th><th>Sessions</th><th>Shots</th><th>Hits</th><th>Accuracy</th></tr></thead>
+      <tbody>
+        ${rows.map((p) => {
+          const a = hitAccuracy[p];
+          const cls = a.pct >= 80 ? 'accuracy-high' : a.pct >= 60 ? 'accuracy-mid' : 'accuracy-low';
+          return `<tr>
+            <td style="text-transform:capitalize">${p}</td>
+            <td>${a.sessions}</td>
+            <td>${a.shots}</td>
+            <td>${a.hits}</td>
+            <td class="${cls}">${pct(a.pct)}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>`;
+}
+
+function renderWeaponsTable(byWeapon: Record<string, WeaponBucket>): string {
+  const entries = Object.entries(byWeapon);
+  if (entries.length === 0) return '<p class="no-data">No weapon data</p>';
+  return `
+    <table>
+      <thead><tr><th>Weapon</th><th>Sessions</th><th>Shots</th><th>Hits</th><th>Accuracy</th></tr></thead>
+      <tbody>
+        ${entries.map(([name, wb]) => {
+          const cls = wb.pct >= 80 ? 'accuracy-high' : wb.pct >= 60 ? 'accuracy-mid' : 'accuracy-low';
+          return `<tr>
+            <td>${name}</td>
+            <td>${wb.sessions}</td>
+            <td>${wb.shots}</td>
+            <td>${wb.hits}</td>
+            <td class="${cls}">${pct(wb.pct)}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>`;
+}
+
+function renderSpotterCards(sp: SpotterStats): string {
+  if (sp.engagements === 0) return '<p class="no-data">No spotter activity</p>';
+  return `
+    <div class="metric-grid">
+      <div class="metric-card">
+        <div class="metric-value">${sp.engagements}</div>
+        <div class="metric-label">Engagements</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-value">${sp.shotsObserved}</div>
+        <div class="metric-label">Shots Observed</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-value accent">${pct(sp.hitPct)}</div>
+        <div class="metric-label">Hit Rate</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-value accent">${sp.firstShotTotal > 0 ? pct(sp.firstShotPct) : '—'}</div>
+        <div class="metric-label">1st Shot Hit %</div>
+      </div>
+    </div>`;
+}
+
+function renderTimeLimitSection(tl: UserReportData['timeLimit']): string {
+  const hasAny = tl.withTimeLimit.sessions > 0 || tl.noTimeLimit.sessions > 0;
+  if (!hasAny) return '<p class="no-data">No data</p>';
+  const rows = [
+    { label: 'With Time Limit', b: tl.withTimeLimit },
+    { label: 'No Time Limit', b: tl.noTimeLimit },
+  ].filter((r) => r.b.sessions > 0);
+  return `
+    <table>
+      <thead><tr><th>Condition</th><th>Sessions</th><th>Shots</th><th>Hits</th><th>Accuracy</th></tr></thead>
+      <tbody>
+        ${rows.map(({ label, b }) => {
+          const cls = b.pct >= 80 ? 'accuracy-high' : b.pct >= 60 ? 'accuracy-mid' : 'accuracy-low';
+          return `<tr>
+            <td>${label}</td>
+            <td>${b.sessions}</td>
+            <td>${b.shots}</td>
+            <td>${b.hits}</td>
+            <td class="${cls}">${pct(b.pct)}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>`;
+}
+
+function renderUserSection(ud: UserReportData, isFirst: boolean): string {
+  const accCls = ud.totals.accuracy >= 80 ? 'accuracy-high' : ud.totals.accuracy >= 60 ? 'accuracy-mid' : 'accuracy-low';
+  return `
+  <div class="user-section" style="${isFirst ? '' : 'page-break-before: always;'}">
+    <div class="user-header">
+      <div>
+        <h2 class="user-name">${ud.userName}</h2>
+        <span class="role-badge">${ud.role}</span>
+      </div>
+      <div class="user-totals">
+        <div class="total-chip"><span class="total-val">${ud.totals.sessions}</span><span class="total-lbl">Sessions</span></div>
+        <div class="total-chip"><span class="total-val">${ud.totals.shots}</span><span class="total-lbl">Shots</span></div>
+        <div class="total-chip"><span class="total-val ${accCls}">${pct(ud.totals.accuracy)}</span><span class="total-lbl">Accuracy</span></div>
+      </div>
+    </div>
+
+    <div class="subsection">
+      <h3 class="subsection-title">Grouping Performance</h3>
+      ${renderGroupingTable(ud.grouping)}
+    </div>
+
+    <div class="subsection">
+      <h3 class="subsection-title">Hit Accuracy by Position</h3>
+      ${renderAccuracyTable(ud.hitAccuracy)}
+    </div>
+
+    <div class="subsection">
+      <h3 class="subsection-title">Pressure (Time Limit)</h3>
+      ${renderTimeLimitSection(ud.timeLimit)}
+    </div>
+
+    <div class="subsection">
+      <h3 class="subsection-title">Weapons</h3>
+      ${renderWeaponsTable(ud.byWeapon)}
+    </div>
+
+    <div class="subsection">
+      <h3 class="subsection-title">Spotter Performance</h3>
+      ${renderSpotterCards(ud.spotter)}
+    </div>
+  </div>`;
+}
+
+export function generateTeamReportHTML(data: TeamReportData): string {
+  const { team, dateRange, generatedAt, users, summary } = data;
+  const dateRangeStr = `${format(dateRange.start, 'MMM d, yyyy')} – ${format(dateRange.end, 'MMM d, yyyy')}`;
+  const accCls = summary.accuracy >= 80 ? 'accuracy-high' : summary.accuracy >= 60 ? 'accuracy-mid' : 'accuracy-low';
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Team Report – ${team.name}</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      color: #1F2937;
+      line-height: 1.5;
+      background: #fff;
+      padding: 40px;
+    }
+    .cover { text-align: center; padding-bottom: 32px; border-bottom: 2px solid #E5E7EB; margin-bottom: 32px; }
+    .cover-logo { font-size: 11px; font-weight: 700; letter-spacing: 0.12em; color: #9CA3AF; margin-bottom: 16px; }
+    .cover-title { font-size: 30px; font-weight: 800; color: #111827; margin-bottom: 6px; }
+    .cover-sub { font-size: 14px; color: #6B7280; margin-bottom: 20px; }
+    .cover-generated { font-size: 11px; color: #9CA3AF; }
+    .summary-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-bottom: 40px; }
+    .summary-card { background: #F9FAFB; border-radius: 8px; padding: 16px; text-align: center; }
+    .summary-value { font-size: 26px; font-weight: 800; color: #111827; }
+    .summary-label { font-size: 11px; color: #6B7280; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.05em; }
+    .user-section { padding: 28px 0; }
+    .user-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 24px; padding-bottom: 16px; border-bottom: 2px solid ${ACCENT}33; }
+    .user-name { font-size: 20px; font-weight: 700; color: #111827; margin-bottom: 6px; }
+    .role-badge { display: inline-block; padding: 2px 10px; border-radius: 99px; font-size: 11px; font-weight: 600; background: ${ACCENT}18; color: ${ACCENT}; text-transform: capitalize; }
+    .user-totals { display: flex; gap: 12px; }
+    .total-chip { background: #F3F4F6; border-radius: 8px; padding: 8px 14px; text-align: center; }
+    .total-val { display: block; font-size: 18px; font-weight: 700; color: #111827; }
+    .total-lbl { display: block; font-size: 10px; color: #6B7280; text-transform: uppercase; letter-spacing: 0.05em; }
+    .subsection { margin-bottom: 20px; }
+    .subsection-title { font-size: 13px; font-weight: 700; color: ${ACCENT}; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid #E5E7EB; }
+    table { width: 100%; border-collapse: collapse; }
+    th { text-align: left; padding: 8px 10px; background: #F3F4F6; font-size: 11px; font-weight: 700; color: #374151; border-bottom: 2px solid #E5E7EB; text-transform: uppercase; letter-spacing: 0.04em; }
+    td { padding: 8px 10px; font-size: 13px; border-bottom: 1px solid #F3F4F6; }
+    tr:last-child td { border-bottom: none; }
+    .accuracy-high { color: #059669; font-weight: 700; }
+    .accuracy-mid { color: #D97706; font-weight: 700; }
+    .accuracy-low { color: #DC2626; font-weight: 700; }
+    .accent { color: ${ACCENT}; font-weight: 700; }
+    .metric-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+    .metric-card { background: #F9FAFB; border-radius: 8px; padding: 12px; text-align: center; }
+    .metric-value { font-size: 22px; font-weight: 800; color: #111827; }
+    .metric-label { font-size: 10px; color: #6B7280; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.04em; }
+    .no-data { color: #9CA3AF; font-style: italic; font-size: 13px; padding: 10px 0; }
+    .footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid #E5E7EB; text-align: center; font-size: 11px; color: #9CA3AF; }
+  </style>
+</head>
+<body>
+  <div class="cover">
+    <div class="cover-logo">RETICLEIQ · TEAM PERFORMANCE REPORT</div>
+    <h1 class="cover-title">${team.name}</h1>
+    <div class="cover-sub">${dateRangeStr}</div>
+    <div class="cover-generated">Generated ${format(generatedAt, "MMMM d, yyyy 'at' h:mm a")}</div>
+  </div>
+
+  <div class="summary-grid">
+    <div class="summary-card">
+      <div class="summary-value">${summary.members}</div>
+      <div class="summary-label">Members</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-value">${summary.sessions}</div>
+      <div class="summary-label">Sessions</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-value">${summary.shots}</div>
+      <div class="summary-label">Total Shots</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-value">${summary.hits}</div>
+      <div class="summary-label">Total Hits</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-value ${accCls}">${pct(summary.accuracy)}</div>
+      <div class="summary-label">Team Accuracy</div>
+    </div>
+  </div>
+
+  ${users.map((ud, i) => renderUserSection(ud, i === 0)).join('\n')}
+
+  <div class="footer">
+    Generated by ReticleIQ · ${format(generatedAt, 'MMMM d, yyyy')}
+  </div>
+</body>
+</html>`;
+}
+
+// ============================================================================
+// PDF EXPORT + SHARE
+// ============================================================================
+
+export async function shareTeamReportPDF(data: TeamReportData): Promise<void> {
+  const html = generateTeamReportHTML(data);
+  const { uri } = await Print.printToFileAsync({ html, base64: false });
+
+  if (await Sharing.isAvailableAsync()) {
+    await Sharing.shareAsync(uri, {
+      mimeType: 'application/pdf',
+      dialogTitle: `Team Report – ${data.team.name}`,
+      UTI: 'com.adobe.pdf',
+    });
+  } else {
+    throw new Error('Sharing is not available on this device');
+  }
+}


### PR DESCRIPTION
Adds a Generate Report menu item for commanders that opens a date-range form sheet, fetches per-user session stats (grouping, accuracy, weapons, spotter), and shares a formatted PDF via expo-print + expo-sharing.

Made-with: Cursor